### PR TITLE
fix: prevent "undefined array key error" in AttachPermissionsToGroups…

### DIFF
--- a/Classes/AttachPermissionsToGroups.php
+++ b/Classes/AttachPermissionsToGroups.php
@@ -110,7 +110,7 @@ final class AttachPermissionsToGroups
                 continue;
             }
             if ($configurationForResource['fields'] === '*' || $configurationForResource['fields'] === ['*']) {
-                foreach ($GLOBALS['TCA'][$tableName]['columns'] as $fieldName => $fieldConfiguration) {
+                foreach ($GLOBALS['TCA'][$tableName]['columns'] ?? [] as $fieldName => $fieldConfiguration) {
                     if ($fieldConfiguration['exclude'] ?? false) {
                         $fieldNames[] = $tableName . ':' . $fieldName;
                     }


### PR DESCRIPTION
… on missing TCA for table

Closes: #7