### PR TITLE
[FEATURE] Add permission sets to be_users

### DIFF
--- a/Classes/AttachPermissionsToGroups.php
+++ b/Classes/AttachPermissionsToGroups.php
@@ -49,6 +49,17 @@ final class AttachPermissionsToGroups
             }
             $finalGroups[] = $group;
         }
+        $user = $event->getUserData();
+        if (!empty($user['permissions_sets'])) {
+            $permissionSetIdentifiers = explode(',', $user['permission_sets']);
+            $group = [];
+            foreach ($permissionSetIdentifiers as $permissionSetIdentifier) {
+                if ($this->registry->has($permissionSetIdentifier)) {
+                    $group = $this->expandGroupPermissionsWithPermissionSet($group, $this->registry->get($permissionSetIdentifier));
+                }
+            }
+            $finalGroups[] = $group;
+        }
         $event->setGroups($finalGroups);
     }
 

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -1,0 +1,13 @@
+<?php
+
+$GLOBALS['TCA']['be_users']['columns']['permission_sets'] = [
+    'label' => 'Permission Sets',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectMultipleSideBySide',
+        'itemsProcFunc' => \B13\PermissionSets\AvailablePermissionSets::class . '->backendGroupSelector',
+        'items' => []
+    ]
+];
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('be_users', 'permission_sets', '', 'after:usergroup');

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,3 +1,7 @@
 CREATE TABLE be_groups (
   permission_sets varchar(2000) DEFAULT ''
 );
+
+CREATE TABLE be_users (
+  permission_sets varchar(2000) DEFAULT ''
+);


### PR DESCRIPTION
Having all groups deployable could be a big effort for large multisite systems. This will help manage large systems avoiding big changes in database if changes were made.