### PR TITLE
Add support for partial module lists

### DIFF
--- a/Build/Packages/permission-sets-examples/Configuration/PermissionSets/some-web-modules.yaml
+++ b/Build/Packages/permission-sets-examples/Configuration/PermissionSets/some-web-modules.yaml
@@ -1,0 +1,3 @@
+label: Allow web_page and web_list modules
+modules:
+  web: ['web_layout', 'web_list']

--- a/Classes/AttachPermissionsToGroups.php
+++ b/Classes/AttachPermissionsToGroups.php
@@ -196,6 +196,12 @@ final class AttachPermissionsToGroups
                 foreach ($subModuleList as $subModuleName) {
                     $finalModules[] = $subModuleName->getIdentifier();
                 }
+            } elseif (is_array($allowedModule)) {
+                foreach ($allowedModule as $subModuleName) {
+                    if ($this->moduleProvider->isModuleRegistered($subModuleName)) {
+                        $finalModules[] = $subModuleName;
+                    }
+                }
             } elseif ((bool)$allowedModule === true) {
                 if ($this->moduleProvider->isModuleRegistered($moduleName)) {
                     $finalModules[] = $moduleName;

--- a/Tests/Functional/AttachPermissionsToGroupsTest.php
+++ b/Tests/Functional/AttachPermissionsToGroupsTest.php
@@ -116,6 +116,19 @@ class AttachPermissionsToGroupsTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function someWebModules(): void
+    {
+        $group = $this->emptyGroup;
+        $group['permission_sets'] = 'b13/permission-sets-examples/some-web-modules';
+        $event = new AfterGroupsResolvedEvent('be_groups', [$group], [1], []);
+        $attachPermissionsToGroups = GeneralUtility::makeInstance(AttachPermissionsToGroups::class);
+        $attachPermissionsToGroups($event);
+        $modGroup = $event->getGroups()[0];
+        self::assertStringContainsString('web_layout', $modGroup['groupMods']);
+        self::assertStringContainsString('web_list', $modGroup['groupMods']);
+    }
+
+    #[Test]
     public function webInfoModule(): void
     {
         $group = $this->emptyGroup;


### PR DESCRIPTION
This adds support for a partial list of modules in addition to `['*']` for including all modules.

Edit: I included a test, but the workflow does not yet run, so I don't know if it's green. The change works for me locally.