### PR TITLE
[FEATURE] Add importFromFile option to support importing existing tsconfig files

### DIFF
--- a/Classes/AttachPermissionsToGroups.php
+++ b/Classes/AttachPermissionsToGroups.php
@@ -165,9 +165,17 @@ final class AttachPermissionsToGroups
             $settings = $this->typoScriptService->convertPlainArrayToTypoScriptArray($settings);
             $settings = ArrayUtility::flatten($settings, '', true);
             foreach ($settings as $key => $value) {
+
+                if ($key === 'importFromFile') {
+                    $group['TSconfig'] .= "\n\r" . $this->buildTsImportStatement($value);
+
+                    continue;
+                }
+
                 $group['TSconfig'] .= "\n\r" . $key . ' = ' . $value;
             }
         }
+
         return $group;
     }
 
@@ -240,5 +248,10 @@ final class AttachPermissionsToGroups
         }
 
         return $allowedMfaProviders;
+    }
+
+    private function buildTsImportStatement(string $file): string
+    {
+        return '@import "' . $file . '"';
     }
 }

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ settings:
         createFoldersInEB: true
     TCEMAIN:
         clearCache: all
+    importFromFile: 'EXT:my_extension/Configuration/TSconfig/user.tsconfig'
 ```
 
 ## ToDo


### PR DESCRIPTION
### Summary

Currently, the settings configuration is converted into tsconfig entries using a simple `key = value` mapping.
Because of this, there is no way to reference or reuse an existing tsconfig file via an `@import` statement.

### What this PR does

This PR introduces a new configuration key: `importFromFile`

When importFromFile is set, the provided file path is converted into a valid `@import` statement, e.g.

`@import "EXT:my_extension/Configuration/TsConfig/user.tsconfig"`


This import is then applied to the generated group tsconfig, allowing existing tsconfig files to be reused instead of duplicating configuration values.